### PR TITLE
Manage game round and prize updates

### DIFF
--- a/packages/foundry/script/DeployPumpkinSpiceLatte.s.sol
+++ b/packages/foundry/script/DeployPumpkinSpiceLatte.s.sol
@@ -13,7 +13,7 @@ contract DeployPumpkinSpiceLatte is Script {
         // Morpho Blue Vault on Sepolia (USDC-based)
         // address vaultAddress = 0x1Ae025197a765bD2263d6eb89B76d82e05286543; //sepolia 
         address vaultAddress = 0xd63070114470f685b75B74D60EEc7c1113d33a3D; // ethereum
-        uint256 roundDuration = 86400; // 1 day
+        uint256 roundDuration = 300; // 5 minutes
 
         uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
         vm.startBroadcast(deployerPrivateKey);

--- a/packages/foundry/src/PumpkinSpiceLatte.sol
+++ b/packages/foundry/src/PumpkinSpiceLatte.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.20;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 interface IERC4626Vault {
     function deposit(uint256 assets, address receiver) external returns (uint256 shares);
@@ -17,7 +18,7 @@ interface IERC4626Vault {
  *      to generate yield, and the accumulated yield is awarded as a prize to a
  *      lucky depositor periodically.
  */
-contract PumpkinSpiceLatte {
+contract PumpkinSpiceLatte is Ownable {
     //-//////////////////////////////////////////////////////////
     //                           STATE
     //-//////////////////////////////////////////////////////////
@@ -63,6 +64,7 @@ contract PumpkinSpiceLatte {
     event Deposited(address indexed user, uint256 amount);
     event Withdrawn(address indexed user, uint256 amount);
     event PrizeAwarded(address indexed winner, uint256 amount);
+    event RoundDurationUpdated(uint256 oldDuration, uint256 newDuration);
 
     //-//////////////////////////////////////////////////////////
     //                        CONSTRUCTOR
@@ -72,7 +74,7 @@ contract PumpkinSpiceLatte {
         address _asset,
         address _vault,
         uint256 _roundDuration
-    ) {
+    ) Ownable(msg.sender) {
         require(IERC4626Vault(_vault).asset() == _asset, "Vault asset mismatch");
         ASSET = _asset;
         VAULT = _vault;
@@ -179,6 +181,22 @@ contract PumpkinSpiceLatte {
         nextRoundTimestamp = block.timestamp + roundDuration;
 
         emit PrizeAwarded(winner, prize);
+    }
+
+    //-//////////////////////////////////////////////////////////
+    //                    OWNER-ONLY FUNCTIONS
+    //-//////////////////////////////////////////////////////////
+
+    /**
+     * @notice Updates the round duration. Only callable by the contract owner.
+     * @param _roundDuration The new round duration in seconds. Must be greater than zero.
+     * @dev This change applies to future rounds. The current `nextRoundTimestamp` is not modified.
+     */
+    function setRoundDuration(uint256 _roundDuration) external onlyOwner {
+        require(_roundDuration > 0, "Duration must be > 0");
+        uint256 old = roundDuration;
+        roundDuration = _roundDuration;
+        emit RoundDurationUpdated(old, _roundDuration);
     }
 
     //-//////////////////////////////////////////////////////////

--- a/src/components/PrizePool.tsx
+++ b/src/components/PrizePool.tsx
@@ -5,19 +5,20 @@ import { pumpkinSpiceLatteAddress, pumpkinSpiceLatteAbi, CONTRACTS } from '@/con
 import { formatUnits } from 'viem';
 
 // Helper function to format time remaining
-const formatTimeRemaining = (timestamp: bigint) => {
+  const formatTimeRemaining = (timestamp: bigint) => {
   const now = BigInt(Math.floor(Date.now() / 1000));
   const secondsRemaining = timestamp - now;
 
-  if (secondsRemaining <= 0) {
+  if (secondsRemaining <= 0n) {
     return 'Next round starting soon!';
   }
 
-  const days = secondsRemaining / BigInt(86400);
-  const hours = (secondsRemaining % BigInt(86400)) / BigInt(3600);
-  const minutes = (secondsRemaining % BigInt(3600)) / BigInt(60);
+  const days = secondsRemaining / 86400n;
+  const hours = (secondsRemaining % 86400n) / 3600n;
+  const minutes = (secondsRemaining % 3600n) / 60n;
+  const seconds = secondsRemaining % 60n;
 
-  return `${days}d ${hours}h ${minutes}m`;
+  return `${days}d ${hours}h ${minutes}m ${seconds}s`;
 };
 
 const PrizePool = () => {
@@ -32,7 +33,7 @@ const PrizePool = () => {
     abi: pumpkinSpiceLatteAbi,
     functionName: 'prizePool',
     query: {
-      refetchInterval: 5000, // Refetch every 5 seconds
+      refetchInterval: 10000, // Refetch every 10 seconds
       enabled: isConnected && !!isSupportedNetwork,
     },
   });

--- a/src/components/UserStats.tsx
+++ b/src/components/UserStats.tsx
@@ -8,10 +8,11 @@ import { useToast } from '@/components/ui/use-toast';
 const formatTimeRemaining = (timestamp: bigint) => {
   const now = BigInt(Math.floor(Date.now() / 1000));
   const secondsRemaining = timestamp - now;
-  if (secondsRemaining <= 0) return 'Ready to draw';
+  if (secondsRemaining <= 0n) return 'Ready to draw';
   const hours = secondsRemaining / 3600n;
   const minutes = (secondsRemaining % 3600n) / 60n;
-  return `${hours}h ${minutes}m`;
+  const seconds = secondsRemaining % 60n;
+  return `${hours}h ${minutes}m ${seconds}s`;
 };
 
 const UserStats = () => {

--- a/src/contracts/PumpkinSpiceLatte.ts
+++ b/src/contracts/PumpkinSpiceLatte.ts
@@ -43,6 +43,15 @@ export const pumpkinSpiceLatteAbi = [
     name: 'Withdrawn',
     type: 'event'
   },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: false, internalType: 'uint256', name: 'oldDuration', type: 'uint256' },
+      { indexed: false, internalType: 'uint256', name: 'newDuration', type: 'uint256' }
+    ],
+    name: 'RoundDurationUpdated',
+    type: 'event'
+  },
   // Read Functions
   { inputs: [], name: 'ASSET', outputs: [{ internalType: 'address', name: '', type: 'address' }], stateMutability: 'view', type: 'function' },
   { inputs: [], name: 'VAULT', outputs: [{ internalType: 'address', name: '', type: 'address' }], stateMutability: 'view', type: 'function' },
@@ -57,8 +66,12 @@ export const pumpkinSpiceLatteAbi = [
   { inputs: [], name: 'totalAssets', outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }], stateMutability: 'view', type: 'function' },
   { inputs: [], name: 'totalPrincipal', outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }], stateMutability: 'view', type: 'function' },
   { inputs: [], name: 'vaultShares', outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }], stateMutability: 'view', type: 'function' },
+  { inputs: [], name: 'owner', outputs: [{ internalType: 'address', name: '', type: 'address' }], stateMutability: 'view', type: 'function' },
   // Write Functions
   { inputs: [], name: 'awardPrize', outputs: [], stateMutability: 'nonpayable', type: 'function' },
   { inputs: [{ internalType: 'uint256', name: '_amount', type: 'uint256' }], name: 'deposit', outputs: [], stateMutability: 'nonpayable', type: 'function' },
-  { inputs: [{ internalType: 'uint256', name: '_amount', type: 'uint256' }], name: 'withdraw', outputs: [], stateMutability: 'nonpayable', type: 'function' }
+  { inputs: [{ internalType: 'uint256', name: '_amount', type: 'uint256' }], name: 'withdraw', outputs: [], stateMutability: 'nonpayable', type: 'function' },
+  { inputs: [{ internalType: 'uint256', name: '_roundDuration', type: 'uint256' }], name: 'setRoundDuration', outputs: [], stateMutability: 'nonpayable', type: 'function' },
+  { inputs: [], name: 'renounceOwnership', outputs: [], stateMutability: 'nonpayable', type: 'function' },
+  { inputs: [{ internalType: 'address', name: 'newOwner', type: 'address' }], name: 'transferOwnership', outputs: [], stateMutability: 'nonpayable', type: 'function' }
 ] as const;


### PR DESCRIPTION
Implement owner-controlled round duration, set default to 5 minutes, and enhance frontend prize updates and countdowns for better user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-a7dd27d0-bbb1-4bce-8e55-c97114172d92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a7dd27d0-bbb1-4bce-8e55-c97114172d92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

