### PR TITLE
Improve USDC deposit approval flow

### DIFF
--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -66,6 +66,21 @@ const Actions = () => {
     hash: approvalHash,
   });
 
+  // Declare deposit hook BEFORE any effects that reference it
+  const { writeContract: deposit, isPending: isDepositing } = useWriteContract({
+    onSuccess: (hash: `0x${string}`) => {
+      setDepositHash(hash);
+      toast({ title: 'Deposit submitted', description: 'Waiting for on-chain confirmation...' });
+    },
+    onError: (error) => {
+      toast({
+        title: 'Deposit Failed',
+        description: error.message,
+        variant: 'destructive',
+      });
+    },
+  });
+
   useEffect(() => {
     if (isApprovalConfirmed) {
       refetchAllowance();
@@ -81,20 +96,6 @@ const Actions = () => {
       }
     }
   }, [isApprovalConfirmed, refetchAllowance, toast, pendingDepositAmount, contractAddress, deposit]);
-
-  const { writeContract: deposit, isPending: isDepositing } = useWriteContract({
-    onSuccess: (hash: `0x${string}`) => {
-      setDepositHash(hash);
-      toast({ title: 'Deposit submitted', description: 'Waiting for on-chain confirmation...' });
-    },
-    onError: (error) => {
-      toast({
-        title: 'Deposit Failed',
-        description: error.message,
-        variant: 'destructive',
-      });
-    },
-  });
 
   const { isLoading: isConfirmingDeposit, isSuccess: isDepositConfirmed } = useWaitForTransactionReceipt({
     hash: depositHash,

--- a/src/components/PrizePool.tsx
+++ b/src/components/PrizePool.tsx
@@ -127,6 +127,12 @@ const PrizePool = () => {
   const totalAssets = totalAssetsData ? `${formatUnits(totalAssetsData as bigint, 6)} USDC` : '-';
   const totalPrincipal = totalPrincipalData ? `${formatUnits(totalPrincipalData as bigint, 6)} USDC` : '-';
 
+  const chainId = chain?.id ?? 11155111;
+  const explorerBase = chainId === 1 ? 'https://etherscan.io' : chainId === 11155111 ? 'https://sepolia.etherscan.io' : 'https://etherscan.io';
+  const lastWinnerLink = typeof lastWinnerData === 'string' && lastWinnerData !== '0x0000000000000000000000000000000000000000'
+    ? `${explorerBase}/address/${lastWinnerData}`
+    : undefined;
+
   return (
     <Card>
       <CardHeader>
@@ -156,7 +162,13 @@ const PrizePool = () => {
         <div>
           <Wallet className="h-8 w-8 mx-auto mb-2 text-green-500" />
           <p className="text-sm text-muted-foreground">Last Winner</p>
-          <p className="text-2xl font-bold truncate">{lastWinner}</p>
+          {lastWinnerLink ? (
+            <a href={lastWinnerLink} target="_blank" rel="noreferrer" className="text-2xl font-bold truncate text-blue-600 hover:underline">
+              {lastWinner}
+            </a>
+          ) : (
+            <p className="text-2xl font-bold truncate">{lastWinner}</p>
+          )}
         </div>
         <div className="md:col-span-3 grid grid-cols-1 sm:grid-cols-2 gap-4 mt-2">
           <div className="rounded border p-4 text-center">

--- a/src/components/Winners.tsx
+++ b/src/components/Winners.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { pumpkinSpiceLatteAbi, CONTRACTS, pumpkinSpiceLatteAddress } from '@/contracts/PumpkinSpiceLatte';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { formatUnits, parseAbiItem } from 'viem';
-import { Award, History, AlertCircle } from 'lucide-react';
+import { Award, History, AlertCircle, ExternalLink } from 'lucide-react';
 
 interface WinnerItem {
 	blockNumber: bigint;
@@ -70,6 +70,9 @@ const Winners = () => {
 		return winners.reduce((acc, w) => (w.winner.toLowerCase() === address.toLowerCase() ? acc + w.amount : acc), 0n);
 	}, [winners, address]);
 
+	const chainId = chain?.id ?? 11155111;
+	const explorerBase = chainId === 1 ? 'https://etherscan.io' : chainId === 11155111 ? 'https://sepolia.etherscan.io' : 'https://etherscan.io';
+
 	return (
 		<Card>
 			<CardHeader>
@@ -103,8 +106,31 @@ const Winners = () => {
 									{winners.map((w, idx) => (
 										<li key={`${w.txHash}-${idx}`} className="p-3 flex items-center justify-between gap-3">
 											<div className="min-w-0">
-												<p className="font-medium text-sm truncate">{w.winner.slice(0, 6)}...{w.winner.slice(-4)}</p>
-												<p className="text-xs text-muted-foreground">Block #{w.blockNumber.toString()}</p>
+												<a
+													href={`${explorerBase}/address/${w.winner}`}
+													target="_blank"
+													rel="noreferrer"
+													className="font-medium text-sm truncate text-blue-600 hover:underline"
+												>
+													{w.winner.slice(0, 6)}...{w.winner.slice(-4)}
+												</a>
+												<p className="text-xs text-muted-foreground flex items-center gap-1">
+													Block #{w.blockNumber.toString()}
+													{w.txHash && (
+														<>
+															<span className="mx-1">·</span>
+															<a
+																href={`${explorerBase}/tx/${w.txHash}`}
+																target="_blank"
+																rel="noreferrer"
+																className="inline-flex items-center gap-1 hover:underline"
+															>
+															<span>tx</span>
+															<ExternalLink className="h-3 w-3" />
+															</a>
+														</>
+													)}
+												</p>
 											</div>
 											<div className="shrink-0 font-semibold">{formatUnits(w.amount, 6)} USDC</div>
 										</li>


### PR DESCRIPTION
Improve USDC deposit UX by chaining approval and deposit, adding loading states and toasts, and link winners to Etherscan.

---
<a href="https://cursor.com/background-agent?bcId=bc-74ba10e7-a778-42c3-bdee-382ef9cf8d12">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-74ba10e7-a778-42c3-bdee-382ef9cf8d12">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

