### PR TITLE
Run tenderly balance setter every five seconds

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "live-testnet": "bash script/live-testnet.sh"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/script/live-testnet.sh
+++ b/script/live-testnet.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENDPOINT="https://virtual.mainnet.us-east.rpc.tenderly.co/15cd7478-f127-4d1a-b1e3-68ab95ae2c13"
+
+payload='{
+    "jsonrpc": "2.0",
+    "method": "tenderly_setBalance",
+    "params": [["0xE58b9ee93700A616b50509C8292977FA7a0f8ce1"], "0xDE0B6B3A7640000"]
+}'
+
+while true; do
+	echo "[live-testnet] $(date -Is) calling tenderly_setBalance..."
+	curl -sS -X POST -H "Content-Type: application/json" -d "$payload" "$ENDPOINT" | cat
+	sleep 5
+done


### PR DESCRIPTION
Add a script to repeatedly call a Tenderly RPC endpoint and an npm script to run it.

---
<a href="https://cursor.com/background-agent?bcId=bc-904b3549-8615-4b35-a878-8c18cf3d7763">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-904b3549-8615-4b35-a878-8c18cf3d7763">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

